### PR TITLE
Made minimal Dialogflow test

### DIFF
--- a/tests/BotMan/DialogFlowTest.php
+++ b/tests/BotMan/DialogFlowTest.php
@@ -5,9 +5,8 @@ namespace Tests\BotMan;
 use Illuminate\Support\Facades\Log;
 use Tests\TestCase;
 use App\Http\Controllers\BotManController;
+use BotMan\BotMan\Middleware\ApiAi;
 use PHPUnit\Framework\Assert as PHPUnit;
-
-
 
 class DialogFlowTest extends TestCase
 {
@@ -16,22 +15,11 @@ class DialogFlowTest extends TestCase
      *
      * @return void
      */
-    public function testDialogFlowQuestion()
+    public function testDialogAPI()
     {
-        $botController = new BotManController();
-        $this->bot->receives('How do I install Laravel?');
-        $b = $botController->handle()->getMessages()[0]->getExtras();
-        PHPUnit::assertEquals('input.question', $b['apiAction']);
-        PHPUnit::assertEquals('question', $b['apiIntent']);
-        PHPUnit::assertEquals('Great Question. Check back later for an answer.', $b['apiReply']);
-    }
-    public function testDialogFlowAnswer()
-    {
-        $botController = new BotManController();
-        $this->bot->receives('Go to Laravel.com and download it from there.');
-        $b = $botController->handle()->getMessages()[0]->getExtras();
-        PHPUnit::assertEquals('input.answer', $b['apiAction']);
-        PHPUnit::assertEquals('fallback', $b['apiIntent']);
-        PHPUnit::assertEquals('Thank you for answering someone\'s question.', $b['apiReply']);
+        $dialogflow = TestDialog::create(getenv("DIALOGFLOW_API_KEY"))->listenForAction();
+        $response = $dialogflow->sendEmptyRequest();
+        $status = intval($response['status']['code'] / 100);
+        PHPUnit::assertEquals( 2, $status );
     }
 }

--- a/tests/BotMan/TestDialog.php
+++ b/tests/BotMan/TestDialog.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Tests\BotMan;
+
+use BotMan\BotMan\Middleware\ApiAi;
+
+class TestDialog extends ApiAi
+{
+    public function sendEmptyRequest()
+    {
+        $response = $this->http->post($this->apiUrl, [], [
+            'query' => 'test',
+            'sessionId' => 'test',
+            'lang' => $this->lang,
+        ], [
+            'Authorization: Bearer '.$this->token,
+            'Content-Type: application/json; charset=utf-8',
+        ], true);
+
+        $this->response = json_decode($response->getContent(), true);
+
+        return $this->response;
+    }
+}


### PR DESCRIPTION
Wrote a class that extends ApiAi to add a method for an empty request to Dialogflow. Rewrote the DialogflowTest class to implement a method that checks the status code from a Dialogflow call. If the status code of the response is of type 200, then the test passes.